### PR TITLE
error_reporting -> E_ALL & ~E_NOTICE

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@
  */
 
 ini_set('display_errors','on');
-error_reporting(E_ALL);
+error_reporting(E_ALL & ~E_NOTICE);
 ini_set('default_charset','UTF-8');
 date_default_timezone_set('UTC');
 


### PR DESCRIPTION
Changing the error_reporting() call in index.php so that Slim is able to display pretty error pages when a page 404's or 403's, instead of the stack traces which were displaying up until now. Now magIRC displays errors as designed. 