### PR TITLE
Fix admin page breaking when viewed via https

### DIFF
--- a/admin/tpl/_main.tpl
+++ b/admin/tpl/_main.tpl
@@ -13,7 +13,7 @@
 <link href="css/jquery-ui.css" rel="stylesheet" type="text/css" />
 <link href="css/datatables.css" rel="stylesheet" type="text/css" />
 {if $cfg->cdn_enable}
-<link href='http://fonts.googleapis.com/css?family=Share' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Share' rel='stylesheet' type='text/css'>
 {else}
 <link href="css/font.css" rel="stylesheet" type="text/css" />
 {/if}
@@ -38,9 +38,9 @@
 {/block}
 {block name="js"}
 {if $cfg->cdn_enable}
-<script type="text/javascript" src="http://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.10.2.min.js"></script>
-<script type="text/javascript" src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.10.3/jquery-ui.min.js"></script>
-<script type="text/javascript" src="http://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/jquery.dataTables.js"></script>
+<script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.10.2.min.js"></script>
+<script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jquery.ui/1.10.3/jquery-ui.min.js"></script>
+<script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/jquery.dataTables.js"></script>
 {else}
 <script type="text/javascript" src="../js/jquery.min.js"></script>
 <script type="text/javascript" src="../js/jquery-ui.min.js"></script>


### PR DESCRIPTION
Change javascript sources to use https:// instead of http:// so the admin panel is usable when viewed over a secure connection